### PR TITLE
Laminas-CLI config interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This very small component provides a couple of PSR-11 factories and opinionated 
 
 At the time of writing, I was unaware of [laminas/laminas-cli](https://github.com/laminas/laminas-cli) which does all the things this lib does and more.
 
-**Once laminas-cli is released, I will likely kill this lib off,** so you should probably just go and check out [the official Laminas component](https://github.com/laminas/laminas-cli)
+**Once laminas-cli is released, I will likely kill this lib off,** so you should probably just go and check out [the official Laminas component](https://github.com/laminas/laminas-cli), that said, it hasn't been released yet so if you want something to install now, this lib will also load commands listed under `config.laminas-cli.commands`, so you can list your commands there and then swap out this library with Laminas CLI when it's released.
 
 Anyhow, this lib assumes that you'll probably be using a PSR-11 compatible container and that you will want to use that container to lazy load your console commands.
 
@@ -60,6 +60,12 @@ return [
     'dependencies' => [
         'factories' => [
             \My\Console\DoAThing::class => \My\Console\DoAThingFactory::class,
+        ],
+    ],
+    // Also, prefer listing commands here instead of under console.commands for future interop with laminas-cli
+    'laminas-cli' => [
+        'commands' => [
+            'my::command' => \Some\Command::class,
         ],
     ],
 ];

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -14,6 +14,9 @@ class ConfigProvider
         return [
             'console' => $this->consoleConfig(),
             'dependencies' => $this->dependencies(),
+            'laminas-cli' => [
+                'commands' => $this->commands(),
+            ],
         ];
     }
 
@@ -37,7 +40,13 @@ class ConfigProvider
         return [
             'name' => 'Application Console',
             'auto_add_invokable_factory' => false,
-            'commands' => [],
+            'commands' => $this->commands(),
         ];
+    }
+
+    /** @return string[] */
+    private function commands() : array
+    {
+        return [];
     }
 }

--- a/src/Container/ContainerCommandLoaderFactory.php
+++ b/src/Container/ContainerCommandLoaderFactory.php
@@ -8,6 +8,7 @@ use Laminas\ServiceManager\ServiceManager;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
 use Traversable;
+use function array_merge;
 use function assert;
 use function is_array;
 

--- a/src/Container/ContainerCommandLoaderFactory.php
+++ b/src/Container/ContainerCommandLoaderFactory.php
@@ -17,7 +17,10 @@ class ContainerCommandLoaderFactory
     {
         $config = $container->has('config') ? $container->get('config') : [];
         assert(is_array($config) || $config instanceof Traversable);
-        $commands = $config['console']['commands'] ?? [];
+        $commands = array_merge(
+            $config['console']['commands'] ?? [],
+            $config['laminas-cli']['commands'] ?? []
+        );
 
         $autoAddInvokableFactory = $config['console']['auto_add_invokable_factory'] ?? false;
         if ($autoAddInvokableFactory) {


### PR DESCRIPTION
Merge commands under laminas-cli.commands with console.commands to enable future interop of configuration with forthcoming laminas cli